### PR TITLE
[MOD] astikar_custom

### DIFF
--- a/astikar_custom/__openerp__.py
+++ b/astikar_custom/__openerp__.py
@@ -39,6 +39,8 @@
         "views/res_users_view.xml",
         "views/purchase_order_view.xml",
         "views/account_invoice_view.xml",
+        "views/mrp_repair_line_view.xml",
+        "views/product_view.xml",
     ],
     "installable": True,
 }

--- a/astikar_custom/models/__init__.py
+++ b/astikar_custom/models/__init__.py
@@ -5,3 +5,4 @@
 from . import mrp_repair
 from . import purchase_order
 from . import account_invoice
+from . import product_product

--- a/astikar_custom/models/product_product.py
+++ b/astikar_custom/models/product_product.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2015 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models, fields
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.multi
+    def _compute_sales_count(self):
+        for product in self:
+            product.repair_line_count = len(product.repair_line_ids)
+
+    repair_line_ids = fields.One2many(
+        comodel_name='mrp.repair.line', inverse_name='product_id',
+        string='Repair line', domain=[('type', '=', 'add')])
+    repair_line_count = fields.Integer(compute='_compute_sales_count')

--- a/astikar_custom/tests/test_astikar_custom.py
+++ b/astikar_custom/tests/test_astikar_custom.py
@@ -119,3 +119,34 @@ class TestAstikarCustom(common.TransactionCase):
                          "Total amount not correct")
         repair_line.product_uom_qty = 2
         self.assertEqual(repair_line.load_cost, True, "Load cost updated")
+
+    def test_compute_repair_count(self):
+        self.assertEqual(self.product.repair_line_count, 0)
+        repair_line_vals = {
+            'repair_id': self.mrp_repair.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 0,
+            'expected_qty': 2,
+            'name': self.product.name,
+            'product_uom': self.product.uom_id.id,
+            'type': 'add',
+            'location_id': self.location,
+            'location_dest_id': self.product.property_stock_production.id,
+            'price_unit': 2,
+            'to_invoice': True}
+        self.env['mrp.repair.line'].create(repair_line_vals)
+        self.assertEqual(len(self.product.repair_line_ids), 1)
+        repair_line_vals2 = {
+            'repair_id': self.mrp_repair.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 0,
+            'expected_qty': 2,
+            'name': self.product.name,
+            'product_uom': self.product.uom_id.id,
+            'type': 'remove',
+            'location_id': self.location,
+            'location_dest_id': self.product.property_stock_production.id,
+            'price_unit': 2,
+            'to_invoice': True}
+        self.env['mrp.repair.line'].create(repair_line_vals2)
+        self.assertEqual(len(self.product.repair_line_ids), 1)

--- a/astikar_custom/views/astikar_custom_view.xml
+++ b/astikar_custom/views/astikar_custom_view.xml
@@ -58,6 +58,22 @@
             <field name="header_spacing">65</field>
             <field name="dpi">90</field>
         </record>
+        
+        <record id="paperformat_astikar_quotation" model="report.paperformat">
+            <field name="name">European A4 Astikar Quotation</field>
+            <field name="default" eval="True" />
+            <field name="format">A4</field>
+            <field name="page_height">0</field>
+            <field name="page_width">0</field>
+            <field name="orientation">Portrait</field>
+            <field name="margin_top">80</field>
+            <field name="margin_bottom">20</field>
+            <field name="margin_left">7</field>
+            <field name="margin_right">7</field>
+            <field name="header_line" eval="False" />
+            <field name="header_spacing">70</field>
+            <field name="dpi">90</field>
+        </record>
 
         <record id="paperformat_astikar_header" model="report.paperformat">
             <field name="name">European A4 Astikar Header</field>

--- a/astikar_custom/views/astikar_layout_view.xml
+++ b/astikar_custom/views/astikar_layout_view.xml
@@ -187,10 +187,10 @@
                             <span t-field="company.partner_id.phone"/>
                             <br />
                             Fax:
-                            <span t-field="company.partner_id.fax" />
-                            <div t-if="(o.partner_id.country_id.id != %(base.es)d)">
-                                <span t-field="o.partner_id.country_id"/>
-                            </div>
+                            <span t-field="company.partner_id.fax" /><br />
+                            <span t-if="(o.partner_id.country_id.id != %(base.es)d)">
+                                <span t-field="o.partner_id.country_id"/><br />
+                            </span>
                             <br />
                             <p t-if="o.partner_id.vat">
                                 VAT:

--- a/astikar_custom/views/astikar_reports.xml
+++ b/astikar_custom/views/astikar_reports.xml
@@ -145,20 +145,22 @@
                                 </table>
                             </div>
                         </div>
-                        <div class="row">
-                            <p>
-                                <b>NOTA:</b>
-                                Si este presupuesto es de su conformidad, agradeceríamos remitiesen el mismo con su
-                                firma de conformidad o correspondiente pedido.
-                            </p>
-                        </div>
-                        <div class="row" style="page-break-inside: avoid">
-                            <div class="col-xs-6">CONFORME CLIENTE</div>
-                            <div class="col-xs-6">
-                                ASTIKAR, S.A.
-                                <p t-field="o.create_uid.partner_id"/>
-                                <img t-if="o.create_uid.signature_logo" t-att-src="'data:image/png;base64,%s' % o.create_uid.signature_logo"
-                                    style="max-height:100px;"/>
+                        <div style="page-break-inside: avoid">
+                            <div class="row">
+                                <p>
+                                    <b>NOTA:</b>
+                                    Si este presupuesto es de su conformidad, agradeceríamos remitiesen el mismo con su
+                                    firma de conformidad o correspondiente pedido.
+                                </p>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6">CONFORME CLIENTE</div>
+                                <div class="col-xs-6">
+                                    ASTIKAR, S.A.
+                                    <p t-field="o.create_uid.partner_id"/>
+                                    <img t-if="o.create_uid.signature_logo" t-att-src="'data:image/png;base64,%s' % o.create_uid.signature_logo"
+                                        style="max-height:100px;"/>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/astikar_custom/views/mrp_repair_line_view.xml
+++ b/astikar_custom/views/mrp_repair_line_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="mrp_repair_line_tree" model="ir.ui.view" >
+            <field name="name">mrp.repair.line.tree</field>
+            <field name="model">mrp.repair.line</field>
+            <field name="arch" type="xml">
+                <tree string="Mrp Repair Lines" create="false">
+                    <field name="product_id"/>
+                    <field name="name" />
+                    <field name="product_uom" string="Unit of Measure" groups="product.group_uom"/>
+                    <field name="price_unit"/>
+                    <field name="product_uom_qty" string="Qty"/>
+                    <field name="lot_id" />
+                    <field name="invoiced"/>
+                    <field name="repair_id" />
+                    <field name="to_invoice" />
+                    <field name="repair_state"/>
+                    <field name="price_subtotal" sum="Total"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="mrp_repair_line_view_search" model="ir.ui.view" >
+            <field name="name">mrp.repair.line.search</field>
+            <field name="model">mrp.repair.line</field>
+            <field name="arch" type="xml">
+                <search string="Mrp Repair Lines">
+                    <group expand="0" string="Group By">
+                        <filter string="Repair order" domain="[]" context="{'group_by':'repair_id'}"/>
+                        <filter string="State" domain="[]" context="{'group_by':'state'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/astikar_custom/views/product_view.xml
+++ b/astikar_custom/views/product_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="product_repair_line_view_form" model="ir.ui.view" >
+            <field name="name">product.repair.line.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view" />
+            <field name="arch" type="xml">
+                <field name="lst_price" position="after">
+                    <field name="repair_line_ids" invisible="1"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="product_repair_action" model="ir.actions.act_window">
+            <field name="name">Repair</field>
+            <field name="res_model">mrp.repair.line</field>
+            <field name="view_id" ref="astikar_custom.mrp_repair_line_tree"/>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('product_id', '=', active_id)]</field>
+            <field name="context">{'search_default_product': active_id, 'default_product': active_id}</field>
+        </record>
+
+        <record id="product_form_view_repair_order_button" model="ir.ui.view">
+            <field name="name">product.product.repair.order</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="sale.product_form_view_sale_order_button"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='buttons']" position="inside">
+                    <button class="oe_inline oe_stat_button" name="%(astikar_custom.product_repair_action)d"
+                        type="action" icon="fa-strikethrough">
+                        <field string="Repair orders" name="repair_line_count" widget="statinfo" />
+                    </button>
+                </xpath>
+                <button name="action_view_sales" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </button>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
El material que vendemos en una orden de reparación, en su ficha de producto, NO FIGURA COMO VENTA.
"En odoo, cuando pone que se ha vendido, tira de objeto pedido de venta, no factura o albarán y menos de línea de imputación" - se nos informa.
Necesitamos que se cree un link que relacione cada línea de salida de material de una orden de reparación como si fuera venta de ese producto.
Así, al pinchar en el botón de venta de un producto, nos lleve a las líneas de reparación en las que ha salido ese producto y si se puede agrupar por orden de reparación, mejor, es decir, en la orden "Tal" se ha vendido "Tanto" del producto cuya ficha de venta estoy mirando.

Actualizados informes
