### PR TITLE
[FIX] galaxia_custom: Show only one time the field "product_tmpl_id",…

### DIFF
--- a/galaxia_custom/__openerp__.py
+++ b/galaxia_custom/__openerp__.py
@@ -18,11 +18,13 @@
         "event",
         "sale_mrp",
         "sale_product_variants",
+        "sale_stock_product_variants",
         "product_variants_types",
         "sale_order_line_attached_check",
         "sale_order_line_performance",
         "sale_service_recurrence_configurator",
         "sale_order_line_service_view",
+        "website_quote_not_unlink"
     ],
     "data": [
         "views/event_view.xml",

--- a/galaxia_custom/models/__init__.py
+++ b/galaxia_custom/models/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2015 Esther Martín - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-
+from . import sale_order_line
 from . import event_event
 from . import account_analytic_account

--- a/galaxia_custom/models/sale_order_line.py
+++ b/galaxia_custom/models/sale_order_line.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    @api.depends('product_id', 'product_tmpl_id')
+    def _compute_product_type(self):
+        super(SaleOrderLine, self)._compute_product_type()
+        for line in self:
+            if not line.product_type and line.product_tmpl_id:
+                line.product_type = line.product_tmpl_id.type

--- a/galaxia_custom/tests/__init__.py
+++ b/galaxia_custom/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_galaxia_custom

--- a/galaxia_custom/tests/test_galaxia_custom.py
+++ b/galaxia_custom/tests/test_galaxia_custom.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestGalaxiaCustom(common.TransactionCase):
+
+    def setUp(self):
+        super(TestGalaxiaCustom, self).setUp()
+        self.account_model = self.env['account.analytic.account']
+        self.project_model = self.env['project.project']
+        self.sale_model = self.env['sale.order']
+        account_vals = {'name': 'account procurement service project',
+                        'date_start': '2016-01-15',
+                        'date': '2016-02-28'}
+        self.account = self.account_model.create(account_vals)
+        project_vals = {'name': 'project 1',
+                        'analytic_account_id': self.account.id}
+        self.project = self.project_model.create(project_vals)
+        service_product = self.env.ref('product.product_product_consultant')
+        service_product.write({'performance': 5.0,
+                               'recurring_service': True})
+        service_product.performance = 5.0
+        service_product.route_ids = [
+            (6, 0,
+             [self.ref('procurement_service_project.route_serv_project')])]
+        sale_vals = {
+            'name': 'sale order 1',
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id,
+            'project_id': self.account.id,
+            'project_by_task': 'no'}
+        sale_line_vals = {
+            'product_tmpl_id': service_product.id,
+            'product_type': False,
+            'name': service_product.name,
+            'product_uom_qty': 7,
+            'product_uos_qty': 7,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price,
+            'performance': 5.0,
+            'january': True,
+            'february': True,
+            'week4': True,
+            'week5': True,
+            'tuesday': True,
+            'thursday': True}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_galaxia_custom(self):
+        self.sale_order.order_line[0]._compute_product_type()
+        self.assertNotEqual(
+            len(self.sale_order.order_line), 0,
+            'Sale order withour lines')

--- a/galaxia_custom/views/sale_order_view.xml
+++ b/galaxia_custom/views/sale_order_view.xml
@@ -12,6 +12,12 @@
                 <tree string="SERVICE sales order lines" position="attributes">
                     <attribute name="editable" />
                 </tree>
+                 <xpath expr="//field[@name='no_service_order_line']/tree//field[@name='product_id']" position="before">
+                     <field name="product_tmpl_id" />
+                 </xpath>
+                 <xpath expr="//field[@name='service_order_line']/tree//field[@name='product_id']" position="before">
+                     <field name="product_tmpl_id" />
+                 </xpath>
                 <xpath expr="//field[@name='no_service_order_line']/form//field[@name='product_id']" position="replace">
                     <field name="product_id" domain="[('type','!=','service')]"
                            context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':False, 'company_id': parent.company_id}"
@@ -68,12 +74,11 @@
                          <field name="delay" class="oe_inline"/> days
                      </div>
                  </xpath>
+                 
                  <xpath expr="//field[@name='no_service_order_line']/form[@string='NO SERVICE sales order lines']/group/group/field[@name='tax_id']" position="before">
-                     <field name="product_tmpl_id" invisible="1"/>
                      <field name="product_packaging" context="{'default_product_tmpl_id': product_tmpl_id, 'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}" on_change="product_packaging_change(parent.pricelist_id, product_id, product_uom_qty, product_uom, parent.partner_id, product_packaging, True, context)" domain="[('product_tmpl_id','=',product_tmpl_id)]" groups="product.group_stock_packaging" />
                  </xpath>
                  <xpath expr="//field[@name='service_order_line']/form[@string='SERVICE sales order lines']/group/group/field[@name='tax_id']" position="before">
-                     <field name="product_tmpl_id" invisible="1"/>
                      <field name="product_packaging" context="{'default_product_tmpl_id': product_tmpl_id, 'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}" on_change="product_packaging_change(parent.pricelist_id, product_id, product_uom_qty, product_uom, parent.partner_id, product_packaging, True, context)" domain="[('product_tmpl_id','=',product_tmpl_id)]" groups="product.group_stock_packaging" />
                  </xpath>
                  <xpath expr="//field[@name='no_service_order_line']/tree[@string='NO SERVICE sales order lines']/field[@name='sequence']" position="after">
@@ -107,12 +112,6 @@
                  <xpath expr="//field[@name='service_order_line']/form[@string='SERVICE sales order lines']/group/group/field[@name='address_allotment_id']" position="after">
                      <field name="property_ids" widget="many2many_tags"
                           groups="sale.group_mrp_properties"/>
-                 </xpath>
-                 <xpath expr="//field[@name='no_service_order_line']/tree//field[@name='product_id']" position="before">
-                     <field name="product_tmpl_id" />
-                 </xpath>
-                 <xpath expr="//field[@name='service_order_line']/tree//field[@name='product_id']" position="before">
-                     <field name="product_tmpl_id" />
                  </xpath>
                 <xpath expr="//field[@name='no_service_order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="order_state" invisible="1"/>


### PR DESCRIPTION
… in sale lines.

Se ha modificado el módulo porque se estaba mostrando 2 veces el campo "product_tmpl_id", en el formulario, no daba error de campo duplicado, pero no mostraba el dato.
