### PR TITLE
[ADD] rockbotic_custom: Put the default "apply_performance_by_ quanti…

### DIFF
--- a/ccg_custom/tests/test_ccg_custom.py
+++ b/ccg_custom/tests/test_ccg_custom.py
@@ -9,6 +9,8 @@ class TestCCGCustom(common.TransactionCase):
 
     def setUp(self):
         super(TestCCGCustom, self).setUp()
+        self.account_model = self.env['account.analytic.account']
+        self.project_model = self.env['project.project']
         self.packaging_obj = self.env['product.packaging']
         self.product_1 = self.env.ref('product.product_product_6')
         self.product_packaging1 = self.packaging_obj.create({
@@ -36,8 +38,16 @@ class TestCCGCustom(common.TransactionCase):
             'Product packaging are not the same')
 
     def test_mo_vals(self):
+        account_vals = {'name': 'account procurement service project',
+                        'date_start': '2025-01-15',
+                        'date': '2025-02-28'}
+        self.account = self.account_model.create(account_vals)
+        project_vals = {'name': 'project 1',
+                        'analytic_account_id': self.account.id}
+        self.project = self.project_model.create(project_vals)
         self.sale_order = self.env['sale.order'].create(
-            {'partner_id': self.ref('base.res_partner_2')})
+            {'partner_id': self.ref('base.res_partner_2'),
+             'project_id': self.account.id})
         vals = {
             'order_id': self.sale_order.id,
             'product_id': self.product.id,

--- a/rockbotic_custom/README.rst
+++ b/rockbotic_custom/README.rst
@@ -1,0 +1,19 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================
+Rockbotic custom
+================
+
+* Personalized sale order line form
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/rockbotic_custom/__init__.py
+++ b/rockbotic_custom/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/rockbotic_custom/__openerp__.py
+++ b/rockbotic_custom/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Rockbotic - Custom",
+    "version": "8.0.1.0.0",
+    "category": "Custom Module",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+    ],
+    "depends": [
+        "sale_order_create_event"
+    ],
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/rockbotic_custom/models/__init__.py
+++ b/rockbotic_custom/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import sale_order_line

--- a/rockbotic_custom/models/sale_order_line.py
+++ b/rockbotic_custom/models/sale_order_line.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    apply_performance_by_quantity = fields.Boolean(default=False)

--- a/rockbotic_custom/views/sale_order_view.xml
+++ b/rockbotic_custom/views/sale_order_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_order_form_sale_create_event_inh_rockbotic" model="ir.ui.view">
+            <field name="name">view.order.form.sale.create.event.inh.rockbotic</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_create_event.view_order_form_inh_sale_create_event" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='order_line']//form//field[@name='apply_performance_by_quantity']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath expr="//field[@name='order_line']//tree//field[@name='apply_performance_by_quantity']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…ty" field to False in sale order lines, and hide in sales order line form.

Nuevo módulo para poner por defecto a "False" el campo ""apply_performance_by_ quantity"" de líneas de pedido de venta, y además ponerlo como invisible en el formulario de líneas de pedido de venta.
