### PR TITLE
[IMP] rockbotict_custom: event.track filtered by confirmed events

### DIFF
--- a/rockbotic_custom/views/event_track_view.xml
+++ b/rockbotic_custom/views/event_track_view.xml
@@ -69,6 +69,10 @@
                 <filter string="Event" position="after">
                     <filter string="Location" context="{'group_by':'address_id'}"/>
                 </filter>
+                <group string="Group By" position="before">
+                    <filter string="Confirmed Events" context="{}"
+                            domain="[('event_id.state', '=', 'confirm')]" />
+                </group>
             </field>
         </record>
         <record id="view_event_track_tree_inh_rockbotic" model="ir.ui.view">


### PR DESCRIPTION
Cambio para fijar el filtro creado manualmente
![imagen_de_skype3](https://user-images.githubusercontent.com/2323616/31014723-b83c6d34-a51c-11e7-97f3-f8da2b86916c.png)
