### PR TITLE
[FIX] rockbotic_website_crm: Send SEPA email from inscription.

### DIFF
--- a/rockbotic_website_crm/models/__init__.py
+++ b/rockbotic_website_crm/models/__init__.py
@@ -5,3 +5,5 @@
 from . import crm_lead
 from . import event_registration
 from . import res_company
+from . import res_partner
+from . import mail_mail

--- a/rockbotic_website_crm/models/crm_lead.py
+++ b/rockbotic_website_crm/models/crm_lead.py
@@ -132,6 +132,10 @@ class CrmLead(models.Model):
                     'subject': template.subject,
                     'reply_to': template.reply_to,
                     'body': template.body_html}
+            if self.partner_id.email:
+                vals['partner_ids'] = [(6, 0, [self.partner_id.id])]
+            if self.partner_id.parent_id and self.partner_id.parent_id.email:
+                vals['partner_ids'] = [(6, 0, [self.partner_id.parent_id.id])]
             wizard = self.env['mail.compose.message'].with_context(
                 default_composition_mode='mass_mail',
                 default_template_id=template.id,
@@ -163,6 +167,10 @@ class CrmLead(models.Model):
                     'subject': template.subject,
                     'reply_to': template.reply_to,
                     'body': template.body_html}
+            if self.partner_id.email:
+                vals['partner_ids'] = [(6, 0, [self.partner_id.id])]
+            if self.partner_id.parent_id and self.partner_id.parent_id.email:
+                vals['partner_ids'] = [(6, 0, [self.partner_id.parent_id.id])]
             mandate = lead.partner_id.parent_id.bank_ids[0].mandate_ids[0]
             wizard = self.env['mail.compose.message'].with_context(
                 default_composition_mode='mass_mail',
@@ -239,6 +247,7 @@ class CrmLead(models.Model):
     def _send_email_to_new_enrollment(self, template):
         partner_obj = self.env['res.partner']
         vals = {'email_from': template.email_from,
+                'email_to': self.email_from,
                 'subject': template.subject,
                 'reply_to': template.reply_to,
                 'body': template.body_html}
@@ -262,4 +271,4 @@ class CrmLead(models.Model):
                     ('type', '=', 'contact')]
             partner = partner_obj.search(cond, limit=1)
             if partner:
-                partner.unlink()
+                partner.delete_after_sending_email = True

--- a/rockbotic_website_crm/models/mail_mail.py
+++ b/rockbotic_website_crm/models/mail_mail.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class MailMail(models.Model):
+    _inherit = 'mail.mail'
+
+    @api.model
+    def _postprocess_sent_message(self, mail, mail_sent=True):
+        if mail_sent:
+            mail._delete_partner_from_first_email()
+        return super(MailMail, self)._postprocess_sent_message(
+            mail, mail_sent=mail_sent)
+
+    @api.multi
+    def _delete_partner_from_first_email(self):
+        self.mapped('recipient_ids').filtered(
+            lambda x: x.delete_after_sending_email).unlink()

--- a/rockbotic_website_crm/models/res_partner.py
+++ b/rockbotic_website_crm/models/res_partner.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, fields
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    delete_after_sending_email = fields.Boolean(
+        string='Delete after sending email', default=False)

--- a/rockbotic_website_crm/tests/test_rockbotic_website_crm.py
+++ b/rockbotic_website_crm/tests/test_rockbotic_website_crm.py
@@ -12,6 +12,7 @@ class TestRockboticWebsiteCrm(TestRockboticCustom):
     def setUp(self):
         super(TestRockboticWebsiteCrm, self).setUp()
         self.partner_model = self.env['res.partner']
+        self.mail_model = self.env['mail.mail']
         self.enroll_model = self.env['crm.lead']
         self.search_action = self.browse_ref(
             'rockbotic_website_crm.res_partner_enroll_search_action')
@@ -113,17 +114,23 @@ class TestRockboticWebsiteCrm(TestRockboticCustom):
             'no_confirm_mail': False,
             'email_from': 'test@rockbotic.com'
         })
+        cond = [('name', '=', 'test@rockbotic.com'),
+                ('display_name', '=', 'test@rockbotic.com'),
+                ('email', '=', 'test@rockbotic.com'),
+                ('type', '=', 'contact')]
+        partner = self.partner_model.search(cond, limit=1)
+        self.assertEquals(len(partner), 1,
+                          'Automatic created partner not found')
+        self.assertEquals(partner.delete_after_sending_email, True,
+                          'Partner not marked to delete')
+        cond = [('recipient_ids', 'in', [partner.id])]
+        mail = self.mail_model.search(cond, limit=1)
+        self.assertEquals(len(mail), 1,
+                          'First email not found')
         enrollment.school_id.user_id = 1
         enrollment._onchange_school_id()
         self.assertEquals(enrollment.user_id, enrollment.school_id.user_id,
                           'Bad school user')
-        cond = [('name', '=', enrollment.email_from),
-                ('display_name', '=', enrollment.email_from),
-                ('email', '=', enrollment.email_from),
-                ('type', '=', 'contact')]
-        partner = self.partner_model.search(cond, limit=1)
-        self.assertEquals(len(partner), 0,
-                          'Partner found after create inscription')
         self.browse_ref(
             'rockbotic_website_crm.email_to_new_enrollment').unlink()
         with self.assertRaises(exceptions.Warning):
@@ -145,7 +152,7 @@ class TestRockboticWebsiteCrm(TestRockboticCustom):
                 'medium_id': self.ref(
                     'rockbotic_website_crm.crm_medium_student_signup'),
                 'no_confirm_mail': False,
-                'email_from': 'test2@rockbotic.com'
+                'email_from': 'test3@rockbotic.com'
             })
         self.assertFalse(self.enrollment.event_registration_id)
         self.assertFalse(self.enrollment.partner_id)

--- a/rockbotic_website_crm/views/crm_lead_view.xml
+++ b/rockbotic_website_crm/views/crm_lead_view.xml
@@ -53,6 +53,8 @@
                     <field name="create_date"/>
                     <field name="stage_id" />
                     <field name="contact_name" string="Student" />
+                    <field name="birth_date"/>
+                    <field name="course"/>
                     <field name="partner_name" string="Responsible" />
                     <field name="school_id" />
                     <field name="event_id" />
@@ -270,7 +272,7 @@
             <field name="name">Confirmation of place from inscription</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="email_from">${object.company_id.email or ''}</field>
-            <field name="email_to">${object.partner_id.parent_id.email or ''}</field>
+            <field name="email_to">${object.partner_id.parent_id.email or object.partner_id.email or ''}</field>
             <field name="reply_to">${object.event_id.user_id.partner_id.email or object.company_id.email}</field>
             <field name="subject">CONFIRMATION OF PLACE ROBOTIC EDUCATIVE. ${object.event_id.address_id.name or ''}. ${object.event_id.name or ''}</field>
             <field name="auto_delete" eval="True"/>
@@ -312,7 +314,7 @@
             <field name="name">Request SEPA to the new registration from inscription</field>
             <field name="model_id" ref="account_banking_mandate.model_account_banking_mandate"/>
             <field name="email_from">${object.company_id.email or ''}</field>
-            <field name="email_to">${object.partner_id.parent_id.email or ''}</field>
+            <field name="email_to">${object.partner_id.parent_id.email or object.partner_id.email or ''}</field>
             <field name="reply_to">${object.company_id.sepa_responsible.email or object.company_id.email}</field>
             <field name="report_template" ref="account_banking_sepa_direct_debit.report_sepa_direct_debit_mandate"/>
             <field name="report_name">${object.name or 'mandato_sepa'}</field>

--- a/rockbotic_website_crm/wizard/res_partner_enroll_search.py
+++ b/rockbotic_website_crm/wizard/res_partner_enroll_search.py
@@ -33,9 +33,11 @@ class ResPartnerEnrollSearch(models.TransientModel):
             partners = partner_obj.search(
                 [('name', 'ilike', lead.contact_name),
                  ('parent_id', '!=', False),
-                 ('registered_partner', '=', 'True')])
+                 ('registered_partner', '=', 'True'),
+                 ('delete_after_sending_email', '=', False)])
             parents = partner_obj.search(
                 [('is_company', '=', True),
+                 ('delete_after_sending_email', '=', False),
                  '|', '|', '|', '|', ('name', 'ilike', lead.partner_name),
                  ('vat', 'ilike', lead.vat),
                  ('email', 'ilike', lead.email_from),
@@ -43,12 +45,14 @@ class ResPartnerEnrollSearch(models.TransientModel):
                  ('mobile', 'ilike', lead.phone)])
             partners |= partner_obj.search(
                 [('parent_id', 'in', parents.ids),
+                 ('delete_after_sending_email', '=', False),
                  ('registered_partner', '=', 'True')])
             if not partners:
                 contact_names = lead.contact_name.split(' ')
                 for contact_name in contact_names:
                     partners |= partner_obj.search(
                         [('name', 'ilike', contact_name),
+                         ('delete_after_sending_email', '=', False),
                          ('registered_partner', '=', 'True'),
                          ('parent_id', '!=', False)]) if contact_name else\
                         partner_obj
@@ -56,11 +60,13 @@ class ResPartnerEnrollSearch(models.TransientModel):
                 for parent_name in parent_names:
                     parents = partner_obj.search(
                         [('is_company', '=', True),
+                         ('delete_after_sending_email', '=', False),
                          ('name', 'ilike', parent_name),
                          ('parent_id', '=', False)]) if parent_name else\
                         partner_obj
                 partners |= partner_obj.search(
                     [('parent_id', 'in', parents.ids),
+                     ('delete_after_sending_email', '=', False),
                      ('registered_partner', '=', 'True')])
             if partners:
                 res.update({


### PR DESCRIPTION
Arregla envio de email SEPA desde inscripciones. Mostrar la fecha de nacimiento, y el curso en el tree de inscripciones.
Además se ha modificado el módulo, para que se borre el partner que crea automáticamente el sistema, cuando se envíe el primer email, o cuando se borre el mismo.