### PR TITLE
[IMP] igalia_custom: quitar ejecución on_change al cambiar la cantidad en facturas.

### DIFF
--- a/igalia_custom/__openerp__.py
+++ b/igalia_custom/__openerp__.py
@@ -19,14 +19,15 @@
         "report",
         "sale",
         "account_invoice_pricelist",
-        "hr_timesheet_invoice"
+        "hr_timesheet_invoice",
     ],
     "data": [
         "views/igalia_layout_view.xml",
         "views/product_view.xml",
         "views/igalia_report_view.xml",
         "views/igalia_custom_view.xml",
-        "views/account_analytic_view.xml"
+        "views/account_analytic_view.xml",
+        "views/account_invoice_view.xml",
     ],
     "installable": True,
 }

--- a/igalia_custom/views/account_invoice_view.xml
+++ b/igalia_custom/views/account_invoice_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record id="invoice_form_inherit_view" model="ir.ui.view">
+        <field name="name">account.invoice.inherit.form.view</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account_invoice_pricelist.view_account_invoice_customer_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line']/tree//field[@name='quantity']" position="attributes">
+                <attribute name="on_change"/>
+            </xpath>
+        </field>
+    </record>
+</data>
+</openerp>


### PR DESCRIPTION
El cliente reclama que al cambiar la cantidad de una línea de factura le desconfigura el precio establecido incluso la cuenta analítica establecida. Por ello he quitado la ejecución del on_change de dicho campo, ya que dicha función se añade en ese punto para el recalculo de precio en base a la cantidad y ellos el precio ya lo establecen de antemano.

@avanzosc/developers review when possible
