### PR TITLE
[FIX] rockbotic_custom: Catch subject from email template when send e…

### DIFF
--- a/rockbotic_custom/models/event.py
+++ b/rockbotic_custom/models/event.py
@@ -39,7 +39,8 @@ class EventEvent(models.Model):
                     default_model='event.registration',
                     default_res_id=registration.id,
                     force_send=True
-                ).create({'body': body})
+                ).create({'subject': template.subject,
+                          'body': body})
                 wizard.send_mail()
 
     @api.onchange('group_description')


### PR DESCRIPTION
…mail from event to registrations.
Coger el asunto de la plantilla de email, cuando se manda un email desde el evento a sus registros.