### PR TITLE
[IMP] rockbotic_custom: If the confirmation date of the registration …

### DIFF
--- a/rockbotic_custom/__openerp__.py
+++ b/rockbotic_custom/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Rockbotic - Custom",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.1.0",
     "category": "Custom Module",
     "license": "AGPL-3",
     "author": "AvanzOSC",

--- a/rockbotic_custom/models/event.py
+++ b/rockbotic_custom/models/event.py
@@ -136,3 +136,13 @@ class EventRegistration(models.Model):
                 vals = {'submitted_evaluation': 'yes',
                         'submitted_evaluation_error': ''}
             registration.write(vals)
+
+    def _prepare_wizard_registration_open_vals(self):
+        vals = super(
+            EventRegistration, self)._prepare_wizard_registration_open_vals()
+        today = fields.Date.from_string(fields.Date.context_today(self))
+        if (today > vals.get('from_date') and today.month !=
+                vals.get('from_date').month):
+            new_date = '{}-{}-01'.format(today.year, today.month)
+            vals['from_date'] = new_date
+        return vals

--- a/rockbotic_custom/tests/test_rockbotic_custom.py
+++ b/rockbotic_custom/tests/test_rockbotic_custom.py
@@ -3,6 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 import openerp.tests.common as common
 from openerp import exceptions
+from openerp import fields
 
 
 class TestRockboticCustom(common.TransactionCase):
@@ -256,3 +257,17 @@ class TestRockboticCustom(common.TransactionCase):
         res = child_account.with_context(only_name=True).name_get()[0][1]
         self.assertNotIn(parent_account.name, res,
                          'Parent name found in children name')
+
+    def test_prepare_wizard_registration_open_vals(self):
+        today = fields.Date.from_string(fields.Date.today())
+        new_date = '{}-{}-01'.format(today.year, today.month)
+        self.event_date_begin = '2016-12-12 15:00:00'
+        registration_vals = {'event_id': self.event.id,
+                             'partner_id': self.partner.id,
+                             'date_start': '2016-12-12 15:00:00'}
+        registration = self.env['event.registration'].create(
+            registration_vals)
+        vals = registration._prepare_wizard_registration_open_vals()
+        self.assertEqual(
+            vals.get('from_date', False), new_date,
+            'Bad from_date in registration')


### PR DESCRIPTION
…is greater than the date of the start of the registration, take the day 1 of the current month as the start date of the registration.
Si el día que se confirma un registro es mayor que la fecha de inicio del registro, coger el día 1 del mes/año en que se confirma el registro, y ponerlo como fecha de inicio del registro.