### PR TITLE
[IMP] galaxia_custom: Show dates an hours in sale orde lines, an new …

### DIFF
--- a/galaxia_custom/__openerp__.py
+++ b/galaxia_custom/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Galaxia - Custom",
-    "version": "8.0.2.1.0",
+    "version": "8.0.3.0.0",
     "category": "Custom Module",
     "license": "AGPL-3",
     "author": "AvanzOSC",
@@ -40,7 +40,8 @@
         "sale_order_training_plan",
         "event_track_info",
         "event_track_merge",
-        "sale_order_back2draft"
+        "sale_order_back2draft",
+        "base_location"
     ],
     "data": [
         "data/request_link_data.xml",
@@ -49,10 +50,13 @@
         "views/event_view.xml",
         "views/account_analytic_view.xml",
         "views/sale_order_view.xml",
+        "views/sale_order_line_view.xml",
         "views/account_view.xml",
         "views/crm_view.xml",
         "views/project_task_view.xml",
         "views/event_track_view.xml",
+        "views/event_track_presence_view.xml",
+        "views/crm_lead_view.xml",
         "wizard/wiz_export_presence_information_view.xml",
         "wizard/wiz_export_csv.xml",
         "report/galaxia_layout_view.xml",
@@ -60,6 +64,7 @@
         "report/galaxia_custom_view.xml",
         "report/event_track_presence_report_view.xml",
         "security/project_task_work.xml",
+        "security/ir.model.access.csv",
     ],
     "installable": True,
     "external_dependencies": {

--- a/galaxia_custom/i18n/es.po
+++ b/galaxia_custom/i18n/es.po
@@ -189,8 +189,10 @@ msgid "Product"
 msgstr "Producto"
 
 #. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:152
 #: view:website:account.report_invoice_document
 #: view:website:galaxia_custom.report_sale_information_footer
+#, python-format
 msgid "Quantity"
 msgstr "Cantidad"
 
@@ -373,4 +375,241 @@ msgstr "Debe de definir un horario planificado, en el contrato de venta: %s"
 #, python-format
 msgid "Session %s for %s"
 msgstr "Sesión %s para %s"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:156
+#: view:sale.order:galaxia_custom.view_order_form_service_view_inh_galaxia
+#: field:sale.order.line,session_description:0
+#, python-format
+msgid "Session description"
+msgstr "Descripción de la sesión"
+
+#. module: galaxia_custom
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search2
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search3
+#: field:account.analytic.account,recoverable:0
+#: view:event.track.presence:galaxia_custom.event_track_presence_type_hour_search_view_inh_galaxia
+#: field:event.track.presence,recoverable:0
+msgid "Recoverable"
+msgstr "Recuperable"
+
+#. module: galaxia_custom
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search2
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search3
+#: selection:account.analytic.account,recoverable:0
+#: view:event.track.presence:galaxia_custom.event_track_presence_type_hour_search2_view_inh_galaxia
+msgid "It recovers"
+msgstr "Se recupera"
+
+#. module: galaxia_custom
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search2
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search3
+#: selection:account.analytic.account,recoverable:0
+#: view:event.track.presence:galaxia_custom.event_track_presence_type_hour_search2_view_inh_galaxia
+msgid "He does not recover"
+msgstr "No se recupera"
+
+#. module: galaxia_custom
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search2
+#: view:account.analytic.account:galaxia_custom.view_account_analytic_account_search3
+#: selection:account.analytic.account,recoverable:0
+#: view:event.track.presence:galaxia_custom.event_track_presence_type_hour_search2_view_inh_galaxia
+msgid "Is discounted"
+msgstr "Se descuenta"
+
+#. module: galaxia_custom
+#: view:sale.order:galaxia_custom.view_order_form_inh_galaxia
+msgid "Modify lines"
+msgstr "Modicar líneas"
+
+#. module: galaxia_custom
+#: field:account.analytic.account.historical,date:0
+#: view:project.task.work:galaxia_custom.project_task_work_search_inh_galaxiacustom
+#: field:sale.order.line.historical,date:0
+msgid "Date"
+msgstr "Fecha"
+
+#. module: galaxia_custom
+#: field:account.analytic.account.historical,user_id:0
+#: view:project.task.work:galaxia_custom.project_task_work_search_inh_galaxiacustom
+#: field:sale.order.line.historical,user_id:0
+msgid "User"
+msgstr "Usuario"
+
+#. module: galaxia_custom
+#: field:account.analytic.account.historical,name:0
+#: field:sale.order.line.historical,name:0
+msgid "Description"
+msgstr "Descripción"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/account_analytic_invoice_line.py:17
+#: code:addons/galaxia_custom/models/sale_order.py:148
+#, python-format
+msgid "Price unit"
+msgstr "Precio unitario"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:186
+#, python-format
+msgid "January"
+msgstr "Enero"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:190
+#, python-format
+msgid "February"
+msgstr "Febrero"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:194
+#, python-format
+msgid "March"
+msgstr "Marzo"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:198
+#, python-format
+msgid "April"
+msgstr "Abril"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:202
+#, python-format
+msgid "May"
+msgstr "Mayo"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:206
+#, python-format
+msgid "June"
+msgstr "Junio"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:210
+#, python-format
+msgid "July"
+msgstr "Julio"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:214
+#, python-format
+msgid "August"
+msgstr "Agosto"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:218
+#, python-format
+msgid "September"
+msgstr "Septiembre"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:222
+#, python-format
+msgid "October"
+msgstr "Octubre"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:226
+#, python-format
+msgid "November"
+msgstr "Noviembre"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:230
+#, python-format
+msgid "December"
+msgstr "Diciembre"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:234
+#, python-format
+msgid "Week 1"
+msgstr "Semana 1"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:238
+#, python-format
+msgid "Week 2"
+msgstr "Semana 2"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:242
+#, python-format
+msgid "Week 3"
+msgstr "Semana 3"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:246
+#, python-format
+msgid "Week 4"
+msgstr "Semana 4"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:250
+#, python-format
+msgid "Week 5"
+msgstr "Semana 5"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:254
+#, python-format
+msgid "Week 6"
+msgstr "Semana 6"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:90
+#: code:addons/galaxia_custom/models/sale_order.py:258
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Monday"
+msgstr "Lunes"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:95
+#: code:addons/galaxia_custom/models/sale_order.py:262
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Tuesday"
+msgstr "Martes"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:100
+#: code:addons/galaxia_custom/models/sale_order.py:266
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Wednesday"
+msgstr "Miércoles"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:105
+#: code:addons/galaxia_custom/models/sale_order.py:270
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Thursday"
+msgstr "Jueves"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:110
+#: code:addons/galaxia_custom/models/sale_order.py:274
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Friday"
+msgstr "Viernes"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:115
+#: code:addons/galaxia_custom/models/sale_order.py:278
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Saturday"
+msgstr "Sábado"
+
+#. module: galaxia_custom
+#: code:addons/galaxia_custom/models/sale_order.py:120
+#: code:addons/galaxia_custom/models/sale_order.py:282
+#: selection:project.task.work,day:0
+#, python-format
+msgid "Sunday"
+msgstr "Domingo"
 

--- a/galaxia_custom/models/__init__.py
+++ b/galaxia_custom/models/__init__.py
@@ -7,3 +7,5 @@ from . import account_analytic_account
 from . import res_company
 from . import product
 from . import project
+from . import account_analytic_invoice_line
+from . import crm_lead

--- a/galaxia_custom/models/account_analytic_account.py
+++ b/galaxia_custom/models/account_analytic_account.py
@@ -9,3 +9,22 @@ class AccountAnalyticAccount(models.Model):
     _inherit = 'account.analytic.account'
 
     agreement_address = fields.Many2one(comodel_name="res.partner")
+    recoverable = fields.Selection(
+        selection=[('it_recovers', 'It recovers'),
+                   ('not_recover', 'He does not recover'),
+                   ('is_discounted', 'Is discounted')], string='Recoverable')
+    analytic_account_historical_ids = fields.One2many(
+        comodel_name='account.analytic.account.historical',
+        inverse_name='account_id', string='Account analytic historical')
+
+
+class AccountAnalyticAccountHistorical(models.Model):
+    _name = 'account.analytic.account.historical'
+    _description = "Account analytic account historical"
+    _order = "date"
+
+    account_id = fields.Many2one(
+        comodel_name='account.analytic.account', string="Analytic account")
+    date = fields.Datetime(strin="Date")
+    user_id = fields.Many2one(comodel_name='res.users', string="User")
+    name = fields.Char(string="Description")

--- a/galaxia_custom/models/account_analytic_invoice_line.py
+++ b/galaxia_custom/models/account_analytic_invoice_line.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models, api, _
+
+
+class AccountAnalyticInvoiceLine(models.Model):
+    _inherit = 'account.analytic.invoice.line'
+
+    @api.multi
+    def write(self, values):
+        if values.get('price_unit', False):
+            for line in self.filtered(lambda x: x.analytic_account_id):
+                vals = {'account_id': line.analytic_account_id.id,
+                        'date': fields.Datetime.now(),
+                        'user_id': self.env.uid,
+                        'name': u"{}: {}".format(_('Price unit'),
+                                                 line.price_unit)}
+                self.env['account.analytic.account.historical'].create(vals)
+        return super(AccountAnalyticInvoiceLine, self).write(values)

--- a/galaxia_custom/models/crm_lead.py
+++ b/galaxia_custom/models/crm_lead.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class CrmLead(models.Model):
+    _inherit = 'crm.lead'
+
+    street_2 = fields.Char(
+        string='Street', related="partner_id.street")
+    street_22 = fields.Char(
+        string='Street2', related="partner_id.street2")
+    zip2 = fields.Char(
+        string='Zip', related="partner_id.zip")
+    city2 = fields.Char(
+        string='City', related="partner_id.city")
+    state2_id = fields.Many2one(
+        comodel_name='res.country.state', string='State',
+        related='partner_id.state_id')
+    country2_id = fields.Many2one(
+        comodel_name='res.country', string='Country',
+        related='partner_id.country_id')
+    zip2_id = fields.Many2one(
+        comodel_name='res.better.zip', string='City/Location',
+        related='partner_id.zip_id')

--- a/galaxia_custom/models/event.py
+++ b/galaxia_custom/models/event.py
@@ -19,6 +19,13 @@ class EventEvent(models.Model):
 class EventTrackPresence(models.Model):
     _inherit = 'event.track.presence'
 
+    recoverable = fields.Selection(
+        selection=[('it_recovers', 'It recovers'),
+                   ('not_recover', 'He does not recover'),
+                   ('is_discounted', 'Is discounted')],
+        related='event.sale_order.project_id.recoverable', store=True,
+        string='Recoverable')
+
     @api.depends('session', 'session.allowed_partner_ids')
     def _compute_allowed_partner_ids(self):
         all_partners = self.env['marketing.config.settings']._get_parameter(

--- a/galaxia_custom/models/project.py
+++ b/galaxia_custom/models/project.py
@@ -12,6 +12,18 @@ class ProjectProject(models.Model):
     _order = 'name'
 
 
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    def _moves_for_create_task_service_project(self, procurement):
+        vals = super(ProjectTask, self)._moves_for_create_task_service_project(
+            procurement)
+        vals['name'] = '%s:%s' % (
+            procurement.origin or '',
+            procurement.sale_line_id.session_description)
+        return vals
+
+
 class ProjectTaskWork(models.Model):
     _inherit = 'project.task.work'
 

--- a/galaxia_custom/report/galaxia_reports.xml
+++ b/galaxia_custom/report/galaxia_reports.xml
@@ -489,10 +489,7 @@
                        <tbody class="sale_tbody">
                             <tr t-foreach="o._get_service_lines()" t-as="l">
                                 <td>
-                                   <t t-if="l.name and l.training">
-                                    <span t-field="l.training"/>
-                                   </t>
-                                   <t t-if="l.name and not l.training">
+                                   <t t-if="l.name">
                                     <span t-field="l.name"/>
                                    </t>
                                 </td>

--- a/galaxia_custom/security/ir.model.access.csv
+++ b/galaxia_custom/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_sale_order_line_historical","sale.order.line.historical","model_sale_order_line_historical","base.group_sale_salesman",1,1,1,1
+"access_account_analytic_account_historical","account_analytic_account_historical","model_account_analytic_account_historical","account.group_account_user",1,1,1,1
+"access_account_analytic_account_historical","account_analytic_account_historical","model_account_analytic_account_historical","base.group_sale_salesman",1,1,1,1

--- a/galaxia_custom/tests/test_galaxia_custom.py
+++ b/galaxia_custom/tests/test_galaxia_custom.py
@@ -17,10 +17,21 @@ class TestGalaxiaCustom(common.TransactionCase):
         self.wiz_add_model = self.env['wiz.event.append.assistant']
         self.work_model = self.env['project.task.work']
         self.export_model = self.env['wiz.export.presence.information']
+        self.invoice_line_model = self.env['account.analytic.invoice.line']
         account_vals = {'name': 'account procurement service project',
                         'date_start': '2016-01-15',
-                        'date': '2016-02-28'}
+                        'date': '2016-02-28',
+                        'start_time': 15,
+                        'end_time': 18}
         self.account = self.account_model.create(account_vals)
+        calendar_lines_vals = {'name': 'monday',
+                               'dayofweek': '0',
+                               'hour_from': 15,
+                               'hour_to': 18}
+        calendar_vals = {'name': 'Resource calendar',
+                         'attendance_ids': [(0, 0, calendar_lines_vals)]}
+        resource_calendar = self.env['resource.calendar'].create(calendar_vals)
+        self.account.write({'working_hours': resource_calendar.id})
         project_vals = {'name': 'project 1',
                         'analytic_account_id': self.account.id}
         self.project = self.project_model.create(project_vals)
@@ -58,9 +69,34 @@ class TestGalaxiaCustom(common.TransactionCase):
             'thursday': True,
             'friday': True,
             'saturday': True,
-            'sunday': True}
+            'sunday': True,
+            'start_date': '2016-01-15',
+            'end_date': '2016-02-28',
+            'start_hour': 15,
+            'end_hour': 18}
         sale_vals['order_line'] = [(0, 0, sale_line_vals)]
         self.sale_order = self.sale_model.create(sale_vals)
+        sale_line_vals = {
+            'order_id': self.sale_order.id,
+            'product_tmpl_id': service_product.id,
+            'product_type': False,
+            'name': service_product.name,
+            'product_uom_qty': 7,
+            'product_uos_qty': 7,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price,
+            'performance': 5.0,
+            'january': True,
+            'february': True,
+            'week4': True,
+            'week5': True,
+            'monday': True,
+            'tuesday': True,
+            'wednesday': True,
+            'thursday': True,
+            'friday': True,
+            'saturday': True,
+            'sunday': True}
         self.partner = self.env['res.partner'].create({
             'name': 'Test Partner',
         })
@@ -73,6 +109,14 @@ class TestGalaxiaCustom(common.TransactionCase):
         self.env['ir.config_parameter'].create({
             'key': 'show.all.customers.in.presences',
             'value': True})
+        invoice_line_vals = {'analytic_account_id': self.account.id,
+                             'product_id': service_product.id,
+                             'name': 'aaaaaa',
+                             'quantity': 1,
+                             'uom_id': service_product.uom_id.id,
+                             'price_unit': 1}
+        self.analytic_invoice_line = self.invoice_line_model.create(
+            invoice_line_vals)
 
     def test_galaxia_custom(self):
         self.sale_order.action_button_confirm()
@@ -120,3 +164,37 @@ class TestGalaxiaCustom(common.TransactionCase):
         self.sale_order.project_id.working_hours = [(5)]
         with self.assertRaises(exceptions.Warning):
             self.sale_order.action_button_confirm()
+        self.sale_order._compute_count_lines()
+        self.sale_order.order_line[0].write({'price_unit': 1,
+                                             'product_uom_qty': 1,
+                                             'session_description': 'a',
+                                             'january': True,
+                                             'february': True,
+                                             'march': True,
+                                             'april': True,
+                                             'may': True,
+                                             'june': True,
+                                             'july': True,
+                                             'august': True,
+                                             'september': True,
+                                             'october': True,
+                                             'november': True,
+                                             'december': True,
+                                             'week1': True,
+                                             'week2': True,
+                                             'week3': True,
+                                             'week4': True,
+                                             'week5': True,
+                                             'week6': True,
+                                             'monday': True,
+                                             'tuesday': True,
+                                             'wednesday': True,
+                                             'thursday': True,
+                                             'friday': True,
+                                             'saturday': True,
+                                             'sunday': True})
+        historical = self.sale_order.order_line[0].sale_line_historical_ids
+        self.assertEqual(len(historical), 28, 'Bad historical for sale line')
+        self.analytic_invoice_line.price_unit = 5
+        historical = self.account.analytic_account_historical_ids
+        self.assertEqual(len(historical), 1, 'Bad historical for account')

--- a/galaxia_custom/views/account_analytic_view.xml
+++ b/galaxia_custom/views/account_analytic_view.xml
@@ -20,5 +20,89 @@
                 </field>
             </field>
         </record>
+        <record model="ir.ui.view" id="view_account_analytic_account_form2">
+            <field name="name">analytic.analytic.account.form2</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="sale_order_create_event.view_account_analytic_account_form_inh_sale_event" />
+            <field name="arch" type="xml">
+                <field name="working_hours" position="after">
+                    <field name="recoverable" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_account_analytic_account_search">
+            <field name="name">analytic.analytic.account.search</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="sale_order_create_event.view_account_analytic_account_search_inh_sale_event" />
+            <field name="arch" type="xml">
+                <field name="sale" position="after">
+                    <field name="recoverable" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_account_analytic_account_search2">
+            <field name="name">analytic.analytic.account.search2</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account.view_account_analytic_account_search" />
+            <field name="arch" type="xml">
+                <filter string="Open" position="before">
+                    <filter string="It recovers" domain="[('recoverable','=','it_recovers')]" />
+                    <filter string="He does not recover" domain="[('recoverable','=','not_recover')]" />
+                    <filter string="Is discounted" domain="[('recoverable','=','is_discounted')]" />
+                </filter>
+                <filter string="Status" position="after">
+                    <filter string="Recoverable" domain="[]" context="{'group_by':'recoverable'}"/>
+                </filter>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_account_analytic_account_search3">
+            <field name="name">analytic.analytic.account.search3</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account_analytic_analysis.view_account_analytic_account_overdue_search" />
+            <field name="arch" type="xml">
+                <field name="parent_id" position="after">
+                    <field name="recoverable" />
+                </field>
+                <filter string="Contracts not assigned" position="after">
+                    <separator/>
+                    <filter string="It recovers" domain="[('recoverable','=','it_recovers')]" />
+                    <filter string="He does not recover" domain="[('recoverable','=','not_recover')]" />
+                    <filter string="Is discounted" domain="[('recoverable','=','is_discounted')]" />
+                </filter>
+                <filter string="End Month" position="after">
+                    <filter string="Recoverable" domain="[]" context="{'group_by':'recoverable'}"/>
+                </filter>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="view_account_analytic_account_list2">
+            <field name="name">view.account.analytic.account.list2</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="sale_order_create_event.view_account_analytic_account_list_inh_sale_event" />
+            <field name="arch" type="xml">
+                <field name="sale" position="after">
+                    <field name="recoverable"/>
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="account_analytic_account_form_form_inh_galaxia">
+            <field name="name">account.analytic.account.form.form.inh.galaxia</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account_analytic_analysis.account_analytic_account_form_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='recurring_invoice_line_ids']/.." position="after">
+                    <div attrs="{'invisible': [('recurring_invoices','=',False)]}">
+                        <separator string="Historical" />
+                        <field name="analytic_account_historical_ids" readonly="1" nolabel="1">
+                            <tree string="Historical" >
+                                <field name="account_id" invisible="1"/>
+                                <field name="date"/>
+                                <field name="user_id"/>
+                                <field name="name"/>
+                            </tree>
+                        </field>
+                    </div>
+                </xpath>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/galaxia_custom/views/crm_lead_view.xml
+++ b/galaxia_custom/views/crm_lead_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="crm_case_form_view_oppor_inh_galaxia" model="ir.ui.view">
+            <field name="name">crm.case.form.view.oppor.inh.galaxia</field>
+            <field name="model">crm.lead</field>
+            <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
+            <field name="arch" type="xml">
+                <field name="partner_id" position="after">
+                      <label for="street_2" string="Address"/>
+                      <div>
+                          <field name="street_2" placeholder="Street..." readonly="1" />
+                          <field name="street_22" readonly="1" />
+                          <field name="zip2_id" placeholder="City completion" readonly="1"/>
+                          <field name="zip2" placeholder="ZIP" style="width: 34%" readonly="1"/>
+                          <field name="city2" placeholder="City" style="width: 40%" readonly="1"/>
+                          <field name="state2_id" placeholder="State" readonly="1"/>
+                          <field name="country2_id" placeholder="Country" readonly="1"/>
+                      </div>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/galaxia_custom/views/event_track_presence_view.xml
+++ b/galaxia_custom/views/event_track_presence_view.xml
@@ -1,0 +1,39 @@
+<openerp>
+    <data>
+        <record id="event_track_presence_type_hour_tree_view_inh_galaxia" model="ir.ui.view" >
+            <field name="name">event.track.presence.type.hour.tree.view.inh.galaxia</field>
+            <field name="model">event.track.presence</field>
+            <field name="inherit_id" ref="sale_order_create_event_hour.event_track_presence_type_hour_tree_view"/>
+            <field name="arch" type="xml">
+                <field name="type_hour" position="after">
+                    <field name="recoverable" />
+                </field>
+            </field>
+        </record>
+        <record id="event_track_presence_type_hour_search_view_inh_galaxia" model="ir.ui.view" >
+            <field name="name">event.track.presence.type.hour.search.view.inh.galaxia</field>
+            <field name="model">event.track.presence</field>
+            <field name="inherit_id" ref="sale_order_create_event_hour.event_track_presence_type_hour_search_view"/>
+            <field name="arch" type="xml">
+                <field name="type_hour" position="after">
+                    <field name="recoverable" />
+                </field>
+                <filter string="Type hour" position="after">
+                    <filter string="Recoverable" domain="[]" context="{'group_by':'recoverable'}"/>
+                </filter>
+            </field>
+        </record>
+        <record id="event_track_presence_type_hour_search2_view_inh_galaxia" model="ir.ui.view" >
+            <field name="name">event.track.presence.type.hour.search2.view.inh.galaxia</field>
+            <field name="model">event.track.presence</field>
+            <field name="inherit_id" ref="event_track_assistant.event_track_presence_search_view"/>
+            <field name="arch" type="xml">
+                <filter name="canceled" position="after">
+                    <filter string="It recovers" domain="[('recoverable','=','it_recovers')]" />
+                    <filter string="He does not recover" domain="[('recoverable','=','not_recover')]" />
+                    <filter string="Is discounted" domain="[('recoverable','=','is_discounted')]" />
+                </filter>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/galaxia_custom/views/sale_order_line_view.xml
+++ b/galaxia_custom/views/sale_order_line_view.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_order_line_form2_inh_galaxia" model="ir.ui.view">
+            <field name="name">view_order_line_form2.inh.galaxia</field>
+            <field name="model">sale.order.line</field>
+            <field name="inherit_id" ref="sale.view_order_line_form2" />
+            <field name="arch" type="xml">
+                <field name="product_uom_qty" position="attributes">
+                    <attribute name="readonly">0</attribute>
+                </field>
+                <field name="order_partner_id" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
+                <xpath expr="//field[@name='company_id']/.." position="after">
+                    <field name="recurring_service" invisible="1" colspan="4" />
+                    <label for="session_description" colspan="4"/>
+                    <field name="session_description" nolabel="1" colspan="4"
+                        attrs="{'required':[('recurring_service','=',True)], 'invisible':[('recurring_service','!=',True)]}"/>
+                    <group name="group_month_week_day" colspan="4" col="6"
+                           attrs="{'invisible': [('recurring_service','=',False)]}">
+                       <group name="group_month" colspan="2">
+                           <field name="january" />
+                           <field name="february" />
+                           <field name="march" />
+                           <field name="april" />
+                           <field name="may" />
+                           <field name="june" />
+                           <field name="july" />
+                           <field name="august" />
+                           <field name="september" />
+                           <field name="october" />
+                           <field name="november" />
+                           <field name="december" />
+                       </group>
+                       <group name="group_week" colspan="2">
+                           <field name="week1" />
+                           <field name="week2" />
+                           <field name="week3" />
+                           <field name="week4" />
+                           <field name="week5" />
+                           <field name="week6" />
+                       </group>
+                       <group name="group_day" colspan="2" >
+                           <field name="monday" />
+                           <field name="tuesday" />
+                           <field name="wednesday" />
+                           <field name="thursday" />
+                           <field name="friday" />
+                           <field name="saturday" />
+                           <field name="sunday" />
+                       </group>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+        <record id="sale_order_line_extended_form_view_inh_galaxia" model="ir.ui.view">
+            <field name="name">sale.order.line.extended.form.view.inh.galaxia</field>
+            <field name="model">sale.order.line</field>
+            <field name="inherit_id" ref="sale_product_variants.sale_order_line_extended_form_view" />
+            <field name="arch" type="xml">
+                <field name="product_tmpl_id" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
+            </field>
+        </record>
+        <record id="view_order_line_form2_inh_training_plan_inh_galaxia" model="ir.ui.view">
+            <field name="name">view.order.line.form2.inh.training.plan.inh.galaxia</field>
+            <field name="model">sale.order.line</field>
+            <field name="inherit_id" ref="sale_order_training_plan.view_order_line_form2_inh_training_plan" />
+            <field name="arch" type="xml">
+                <field name="training" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
+                <field name="training" position="after">
+                    <separator string="Historical" colspan="4" />
+                    <field name="sale_line_historical_ids" colspan="4" readonly="1" nolabel="1">
+                        <tree string="Historical">
+                            <field name="sale_line_id" invisible="1" />
+                            <field name="date" />
+                            <field name="user_id" />
+                            <field name="name" />
+                        </tree>
+                    </field>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/galaxia_custom/views/sale_order_view.xml
+++ b/galaxia_custom/views/sale_order_view.xml
@@ -48,6 +48,12 @@
                 <xpath expr="//field[@name='service_order_line']/tree//field[@name='product_id']" position="before">
                     <field name="product_tmpl_id" />
                 </xpath>
+                <xpath expr="//field[@name='service_order_line']/tree//field[@name='name']" position="after">
+                    <field name="session_description" />
+                </xpath>
+                <xpath expr="//field[@name='service_order_line']/tree//field[@name='name']"  position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
                 <xpath expr="//field[@name='no_service_order_line']/form//field[@name='product_id']" position="replace">
                     <field name="product_id" domain="[('type','!=','service')]"
                            context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':False, 'company_id': parent.company_id}"
@@ -105,10 +111,28 @@
                      </div>
                  </xpath>
                  <xpath expr="//form[@string='SERVICE sales order lines']//field[@name='product_id']/../.." position="after">
+                    <group >
+                        <group>
+                            <field name="start_date" string="Start date"
+                                   attrs="{'required':[('recurring_service','=',True)], 'invisible':[('recurring_service','!=',True)]}" />
+                            <field name="start_hour" widget="float_time" string="Start hour"
+                                   attrs="{'invisible':[('recurring_service','!=',True)]}" />
+                        </group>
+                        <group>
+                            <field name="end_date" string="End date"
+                                   attrs="{'required':[('recurring_service','=',True)], 'invisible':[('recurring_service','!=',True)]}" />
+                            <field name="end_hour" widget="float_time" string="End hour"
+                                   attrs="{'invisible':[('recurring_service','!=',True)]}" />
+                        </group>
+                    </group>
                     <label for="periodicity" string="Periodicity" />
                     <field name="periodicity" nolabel="1"/>
                  </xpath>
                  <xpath expr="//form[@string='SERVICE sales order lines']/field[@name='name']" position="after">
+                       <label for="session_description" string="Session description" 
+                            attrs="{'required':[('recurring_service','=',True)], 'invisible':[('recurring_service','!=',True)]}" />
+                       <field name="session_description" nolabel="1"
+                            attrs="{'required':[('recurring_service','=',True)], 'invisible':[('recurring_service','!=',True)]}"/>
                        <label for="Training" string="Training" />
                        <field name="training" nolabel="1"/>
                  </xpath>
@@ -278,6 +302,30 @@
                 <xpath expr="//field[@name='order_line']//tree//field[@name='apply_performance']" position="attributes">
                     <attribute name="invisible">1</attribute>
                 </xpath>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_modify_sale_order_lines">
+            <field name="name">Modify sale order lines</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sale.order.line</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{'default_order_id':active_id,'search_default_order_id':active_id}</field>
+            <field name="domain">[('order_id','=',active_id), ('recurring_service','=',True)]</field>
+        </record>
+        <record id="view_order_form_inh_galaxia" model="ir.ui.view">
+            <field name="name">view.order.form.inh.galaxia</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <h1 position="after">
+                    <div class="oe_right oe_button_box">
+                        <button name="%(action_modify_sale_order_lines)d" type="action"
+                                class="oe_inline oe_stat_button" icon="fa-bookmark-o" >
+                            <field string="Modify lines" name="count_lines" widget="statinfo"/>
+                        </button>
+                    </div>
+                </h1>
             </field>
         </record>
     </data>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -7,6 +7,7 @@ bank-payment
 product-attribute
 purchase-workflow
 account-payment
+partner-contact
 
 # Add a repository url and branch if you need a forked version
 avanzosc-addons https://github.com/avanzosc/odoo-addons
@@ -17,3 +18,4 @@ hr-addons https://github.com/avanzosc/hr-addons
 event-wip https://github.com/avanzosc/event-wip
 # vauxoo-addons https://github.com/Vauxoo/addons-vauxoo
 serviciosbaeza-addons https://github.com/serviciosbaeza/serviciosbaeza-odoo-addons
+


### PR DESCRIPTION
…historicals for sale lines, and analytic account invoice lines.
1.- Mostrar fechas y horas en líneas de pedido de venta, y tener en cuenta estas a la hora de generar sesiones, luego las fechas horas del contrato, y luego calendario definido en el contrato de pedido de venta.
2.- Dos nuevos modelos para historicos de líneas de pedidos de venta, e importe de contrato de venta.
3.- Desde pedidos de venta un atajo para modificar datos de líneas de pedido de venta.
4.- En contratos de pedidos de venta nuevo combo "Recuperable".
5.- En oportunidades campos related a todos los datos referentes a la dirección del partner.
