### PR TITLE
[FIX] rockbotic_custom: Drop field 'Effective Date' in account_invoice

### DIFF
--- a/rockbotic_custom/README.rst
+++ b/rockbotic_custom/README.rst
@@ -10,7 +10,6 @@ Rockbotic custom
 * Access rules for Marketing responsible on mail.followers
 * New field on company for vat exempt invoices.
 * New field in taxes in order to define if it is non-taxable.
-* New field Effective Date in customer invoice tree.
 * Custom reports:
 
   * List of registrations from an event
@@ -26,3 +25,4 @@ Contributors
 * Esther Martín <esthermartin@avanzosc.es>
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 + Gotzon Imaz <gotzonimaz@avanzosc.es>
+

--- a/rockbotic_custom/__openerp__.py
+++ b/rockbotic_custom/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Rockbotic - Custom",
-    "version": "8.0.2.3.0",
+    "version": "8.0.2.4.0",
     "category": "Custom Module",
     "license": "AGPL-3",
     "author": "AvanzOSC",
@@ -44,7 +44,8 @@
         "event_track_info",
         "project_issue",
         "sale_order_back2draft",
-        "event_registration_pa_code"
+        "event_registration_pa_code",
+        "account_utilities"
     ],
     "data": [
         "views/website_template_view.xml",

--- a/rockbotic_custom/i18n/es.po
+++ b/rockbotic_custom/i18n/es.po
@@ -608,12 +608,6 @@ msgid "ETIQUETAS HIJO"
 msgstr "ETIQUETAS HIJO"
 
 #. module: rockbotic_custom
-#: view:account.invoice:rockbotic_custom.view_account_invoice_filter_inh_rockbotic
-#: field:account.invoice,effective_date:0
-msgid "Effective Date"
-msgstr "Fecha de Pago"
-
-#. module: rockbotic_custom
 #: field:event.registration,parent_email:0
 msgid "Email"
 msgstr "Email"

--- a/rockbotic_custom/models/account.py
+++ b/rockbotic_custom/models/account.py
@@ -40,11 +40,3 @@ class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
     literal_header_invoice = fields.Text(string='literal header invoice')
-    effective_date = fields.Date('Effective Date',
-                                 compute='_compute_effective_date', store=True)
-
-    @api.multi
-    @api.depends('payment_ids', 'payment_ids.date')
-    def _compute_effective_date(self):
-        for invoice in self.filtered(lambda c: c.payment_ids):
-            invoice.effective_date = invoice.payment_ids[0].date

--- a/rockbotic_custom/tests/test_rockbotic_custom.py
+++ b/rockbotic_custom/tests/test_rockbotic_custom.py
@@ -268,15 +268,3 @@ class TestRockboticCustom(common.TransactionCase):
         self.assertEqual(
             vals.get('from_date', False), new_date,
             'Bad from_date in registration')
-
-    def test_invoice_pay_date(self):
-
-        self.contract.recurring_create_invoice()
-        invoice = self.invoice_model.search([
-            ('origin', '=', self.contract.code)])
-        invoice.payment_ids = [
-            (0, 0, {'name': 'aaaaaaaaaa',
-                    'date': '2018-05-05'})]
-        invoice.effective_date = '2018-05-05'
-        self.assertEqual(invoice.payment_ids[0].date, invoice.effective_date,
-                         'Bad date')

--- a/rockbotic_custom/views/account_invoice_view.xml
+++ b/rockbotic_custom/views/account_invoice_view.xml
@@ -11,10 +11,9 @@
                 </filter>
                 <filter name="group_by_partner_id" position="after">
                     <filter string="Event" context="{'group_by':'event_id'}"/>
-                    <filter string="Effective Date" context="{'group_by':'effective_date'}"/>
                 </filter>
                 <field name="period_id" position="after">
-                        <field name="effective_date"/>
+                    <field name="number" />
                 </field>
             </field>
         </record>
@@ -26,12 +25,12 @@
                 <field name="partner_id" position="after">
                     <field name="supplier_invoice_number" invisible="context.get('type', False)=='out_invoice'"/>
                 </field>
-                <field name="date_invoice" position="before">
-                    <field name="effective_date"/>
+                <field name="number" position="attributes">
+-                    <attribute name="invisible">1</attribute>
                 </field>
-                 <field name="date_invoice" position="attributes">
-                    <attribute name="invisible">1</attribute>
-                </field>
+                    <field name="date_due" position="after">
+                            <field name="payment_date"/>
+                    </field>
             </field>
         </record>
         <record id="invoice_form_inh_rockbotic_custom" model="ir.ui.view">
@@ -44,6 +43,32 @@
                         <label for="literal_header_invoice"/>
                     </div>
                     <field name="literal_header_invoice" class="oe_inline" placeholder="Literal to print in the header of the invoice" />
+                </field>
+            </field>
+        </record>
+         <record id="view_invoice_tree_inh_rockbotic" model="ir.ui.view">
+            <field name="name">view.invoice.tree.inh.registration.rockbotic</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_tree" />
+            <field name="arch" type="xml">
+                <field name="user_id" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="origin" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+               </field>
+         </record>
+          <record id="view_invoice_tree2_inh_rockbotic" model="ir.ui.view">
+            <field name="name">view.invoice.tree2.inh.rockbotic</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="event_registration_analytic.view_invoice_tree_inh_registration"/>
+            <field name="arch" type="xml">
+                <field name="sale_order_id" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+                <field name="event_address_id" position="after">
+                    <field name="number"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Se ha borrado la creación del campo"effective date" porque ya lo creaba el módulo"account_utilities"