### PR TITLE
[FIX] rockbotic_custom: Fix test error.

### DIFF
--- a/rockbotic_custom/tests/test_rockbotic_custom.py
+++ b/rockbotic_custom/tests/test_rockbotic_custom.py
@@ -257,7 +257,7 @@ class TestRockboticCustom(common.TransactionCase):
 
     def test_prepare_wizard_registration_open_vals(self):
         today = fields.Date.from_string(fields.Date.today())
-        new_date = '{}-{}-01'.format(today.year, today.month)
+        new_date = '{}-{}-01'.format(today.year, str(today.month).zfill(2))
         self.event_date_begin = '{}-{}-01 15:00:00'.format(today.year,
                                                            today.month)
         registration_vals = {'event_id': self.event.id,


### PR DESCRIPTION
Arreglar el test. Al subir un PR por otro custom, ha salido un error en el test de este módulo. El caso es que se esta cogiendo este mes con la función today.month(), y me devuelve un "1", cuando luego en el test se está comparando con un mes "01".